### PR TITLE
Use settings.AUTH_USER_MODEL rather than auth.User.

### DIFF
--- a/quiz/models.py
+++ b/quiz/models.py
@@ -8,6 +8,7 @@ from django.core.validators import MaxValueValidator
 from django.utils.translation import ugettext as _
 from django.utils.timezone import now
 from django.utils.encoding import python_2_unicode_compatible
+from django.conf import settings
 
 from model_utils.managers import InheritanceManager
 
@@ -188,7 +189,7 @@ class Progress(models.Model):
     Data stored in csv using the format:
         category, score, possible, category, score, possible, ...
     """
-    user = models.OneToOneField("auth.User", verbose_name=_("User"))
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, verbose_name=_("User"))
 
     score = models.CommaSeparatedIntegerField(max_length=1024,
                                               verbose_name=_("Score"))
@@ -361,7 +362,7 @@ class Sitting(models.Model):
     with the answer the user gave.
     """
 
-    user = models.ForeignKey('auth.User', verbose_name=_("User"))
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_("User"))
 
     quiz = models.ForeignKey(Quiz, verbose_name=_("Quiz"))
 


### PR DESCRIPTION
Thanks for this quiz app.  I am using django-allauth and ran into problems with models that try to reference the user class.

This is needed when using djang-allauth, since it replaces
auth.User with its own class.
