### PR TITLE
allow html markup in explanation

### DIFF
--- a/quiz/templates/result.html
+++ b/quiz/templates/result.html
@@ -86,7 +86,7 @@
 
 	  <p><strong>{% trans "Explanation" %}:</strong></p>
 	  <div class="well " style="background-color: #fcf8e3;">
-		<p>{{ question.explanation }}</p>
+		<p>{{ question.explanation|safe }}</p>
 	  </div>
 
 	  <hr>


### PR DESCRIPTION
allow html markup in explanation
tested
* url insertion
<a href="http://www.example.com">test</a>
* formatting
<strong>test</strong>
