### PR TITLE
Solve a codepage problem on Windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-readme = open('README.rst').read()
+readme = open('README.rst', encoding="utf-8").read()
 
 setup(
     name='django-quiz-app',


### PR DESCRIPTION
This is my environment:
Windows 10 64-bit build 10586 (The default codepage for cmd.exe is cp950)
Anaconda 3 64-bit Python 3.5.2

When I run `python setup.py install` in django_quiz, I got this error message.
`Traceback (most recent call last):
  File "setup.py", line 3, in <module>
    readme = open('README.rst').read()
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe2 in position 1873: illegal multibyte sequence`
I fixed the problem by adding `encoding='utf-8'` argument to `open` function.