### PR TITLE
Change Bootstrap CDN to HTTPS.

### DIFF
--- a/quiz/templates/base.html
+++ b/quiz/templates/base.html
@@ -8,7 +8,7 @@
 <meta name="description" content="{% block description %}{% endblock %}">
 
 <!-- styles -->
-<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
 
 <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
 <!--[if lt IE 9]>


### PR DESCRIPTION
Changed Bootstrap source to HTTPS in order to avoid mixed content messages when hosting behind an HTTPS proxy.