### PR TITLE
Making the apps django 3 safe

### DIFF
--- a/essay/models.py
+++ b/essay/models.py
@@ -1,10 +1,8 @@
 from __future__ import unicode_literals
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from quiz.models import Question
 
 
-@python_2_unicode_compatible
 class Essay_Question(Question):
 
     def check_if_correct(self, guess):

--- a/essay/models.py
+++ b/essay/models.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from quiz.models import Question
 
 

--- a/multichoice/models.py
+++ b/multichoice/models.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.db import models
 from quiz.models import Question
@@ -54,7 +53,6 @@ class MCQuestion(Question):
         verbose_name_plural = _("Multiple Choice Questions")
 
 
-@python_2_unicode_compatible
 class Answer(models.Model):
     question = models.ForeignKey(MCQuestion, verbose_name=_("Question"), on_delete=models.CASCADE)
 

--- a/multichoice/models.py
+++ b/multichoice/models.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.db import models
 from quiz.models import Question
 

--- a/multichoice/tests.py
+++ b/multichoice/tests.py
@@ -1,7 +1,7 @@
 from django.core.files.base import ContentFile
 from django.db.models.fields.files import ImageFieldFile
 from django.test import TestCase
-from django.utils.six import StringIO
+from six import StringIO
 
 from .models import MCQuestion, Answer
 

--- a/quiz/admin.py
+++ b/quiz/admin.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.contrib import admin
 from django.contrib.admin.widgets import FilteredSelectMultiple
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import Quiz, Category, SubCategory, Progress, Question
 from multichoice.models import MCQuestion, Answer

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError, ImproperlyConfigured
 from django.core.validators import (
     MaxValueValidator, validate_comma_separated_integer_list,
 )
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.timezone import now
 from django.conf import settings
 

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -9,7 +9,6 @@ from django.core.validators import (
 )
 from django.utils.translation import ugettext_lazy as _
 from django.utils.timezone import now
-from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings
 
 from model_utils.managers import InheritanceManager
@@ -25,7 +24,6 @@ class CategoryManager(models.Manager):
         return new_category
 
 
-@python_2_unicode_compatible
 class Category(models.Model):
 
     category = models.CharField(
@@ -43,7 +41,6 @@ class Category(models.Model):
         return self.category
 
 
-@python_2_unicode_compatible
 class SubCategory(models.Model):
 
     sub_category = models.CharField(
@@ -64,7 +61,6 @@ class SubCategory(models.Model):
         return self.sub_category + " (" + self.category.category + ")"
 
 
-@python_2_unicode_compatible
 class Quiz(models.Model):
 
     title = models.CharField(
@@ -541,7 +537,6 @@ class Sitting(models.Model):
         return answered, total
 
 
-@python_2_unicode_compatible
 class Question(models.Model):
     """
     Base class for all question types.

--- a/quiz/tests.py
+++ b/quiz/tests.py
@@ -13,7 +13,7 @@ from django.http import HttpRequest
 from django.template import Template, Context
 from django.test import TestCase
 from django.utils.six import StringIO
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import Category, Quiz, Progress, Sitting, SubCategory
 from .views import (anon_session_score, QuizListView, CategoriesListView,
@@ -57,7 +57,7 @@ class TestQuiz(TestCase):
         self.quiz4 = Quiz.objects.create(id=4,
                                          title='test quiz 4',
                                          description='d4',
-                                         url='T-!£$%^&*Q4')
+                                         url='T-!ï¿½$%^&*Q4')
 
         self.question1 = MCQuestion.objects.create(id=1,
                                                    content='squawk')

--- a/quiz/tests.py
+++ b/quiz/tests.py
@@ -12,7 +12,7 @@ except ImportError:
 from django.http import HttpRequest
 from django.template import Template, Context
 from django.test import TestCase
-from django.utils.six import StringIO
+from six import StringIO
 from django.utils.translation import gettext_lazy as _
 
 from .models import Category, Quiz, Progress, Sitting, SubCategory

--- a/quiz/urls.py
+++ b/quiz/urls.py
@@ -1,7 +1,4 @@
-try:
-    from django.conf.urls import url
-except ImportError:
-    from django.urls import re_path as url
+from django.urls import path
 
 from .views import QuizListView, CategoriesListView, \
     ViewQuizListByCategory, QuizUserProgressView, QuizMarkingList, \
@@ -9,36 +6,36 @@ from .views import QuizListView, CategoriesListView, \
 
 urlpatterns = [
 
-    url(r'^$',
+    path('',
         view=QuizListView.as_view(),
         name='quiz_index'),
 
-    url(r'^category/$',
+    path('category/',
         view=CategoriesListView.as_view(),
         name='quiz_category_list_all'),
 
-    url(r'^category/(?P<category_name>[\w|\W-]+)/$',
+    path('category/<str:category_name>',
         view=ViewQuizListByCategory.as_view(),
         name='quiz_category_list_matching'),
 
-    url(r'^progress/$',
+    path('progress/',
         view=QuizUserProgressView.as_view(),
         name='quiz_progress'),
 
-    url(r'^marking/$',
+    path('marking/',
         view=QuizMarkingList.as_view(),
         name='quiz_marking'),
 
-    url(r'^marking/(?P<pk>[\d.]+)/$',
+    path('marking/<int:pk>/',
         view=QuizMarkingDetail.as_view(),
         name='quiz_marking_detail'),
 
     #  passes variable 'quiz_name' to quiz_take view
-    url(r'^(?P<slug>[\w-]+)/$',
+    path('<slug:slug>/',
         view=QuizDetailView.as_view(),
         name='quiz_start_page'),
 
-    url(r'^(?P<quiz_name>[\w-]+)/take/$',
+    path('<str:quiz_name>/take/',
         view=QuizTake.as_view(),
         name='quiz_question'),
 ]

--- a/true_false/models.py
+++ b/true_false/models.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.db import models
 from quiz.models import Question

--- a/true_false/models.py
+++ b/true_false/models.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.db import models
 from quiz.models import Question
 


### PR DESCRIPTION
According to the release docs for Django 3, `python_2_unicode_compatible` [was removed](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis) (together with compatibility for Python 2). Trying to run your app in Django 3 does not currently work, so I fixed it.